### PR TITLE
G code converter implementation

### DIFF
--- a/SVGtoGCODE/App.config
+++ b/SVGtoGCODE/App.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="SVGtoGCODE.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
@@ -11,4 +16,32 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <userSettings>
+    <SVGtoGCODE.Properties.Settings>
+      <setting name="SizeX" serializeAs="String">
+        <value>148</value>
+      </setting>
+      <setting name="SizeY" serializeAs="String">
+        <value>105</value>
+      </setting>
+      <setting name="OffsetX" serializeAs="String">
+        <value>-74</value>
+      </setting>
+      <setting name="OffsetY" serializeAs="String">
+        <value>70</value>
+      </setting>
+      <setting name="PrintHeight" serializeAs="String">
+        <value>-50</value>
+      </setting>
+      <setting name="MoveHeight" serializeAs="String">
+        <value>-30</value>
+      </setting>
+      <setting name="PrintSpeed" serializeAs="String">
+        <value>15</value>
+      </setting>
+      <setting name="MoveSpeed" serializeAs="String">
+        <value>50</value>
+      </setting>
+    </SVGtoGCODE.Properties.Settings>
+  </userSettings>
 </configuration>

--- a/SVGtoGCODE/ConversionSettings.xaml
+++ b/SVGtoGCODE/ConversionSettings.xaml
@@ -1,0 +1,30 @@
+﻿<Window x:Class="SVGtoGCODE.ConversionSettings"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SVGtoGCODE"
+        mc:Ignorable="d"
+        Title="Conversion Settings" Width="330" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Height="300">
+    <Grid>
+        <TextBox x:Name="SettingBoxSizeX" HorizontalAlignment="Left" Height="25" Margin="165,71,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxSizeX_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxOffsetX" HorizontalAlignment="Left" Height="25" Margin="221,71,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxOffsetX_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxOffsetY" HorizontalAlignment="Left" Height="25" Margin="221,101,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxOffsetY_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxSizeY" HorizontalAlignment="Left" Height="25" Margin="165,101,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxSizeY_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxPrintHeight" HorizontalAlignment="Left" Height="25" Margin="165,131,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxPrintHeight_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxMoveHeight" HorizontalAlignment="Left" Height="25" Margin="165,161,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxMoveHeight_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxPrintSpeed" HorizontalAlignment="Left" Height="25" Margin="165,191,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxPrintSpeed_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <TextBox x:Name="SettingBoxMoveSpeed" HorizontalAlignment="Left" Height="25" Margin="165,221,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="51" TextChanged="SettingBoxMoveSpeed_TextChanged" PreviewTextInput="NumberValidationTextBox"/>
+        <Label Content="Print Surface Size (X)" HorizontalAlignment="Left" Margin="10,71,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Print Surface Size (Y)" HorizontalAlignment="Left" Margin="10,101,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Offset" HorizontalAlignment="Left" Margin="277,71,0,0" VerticalAlignment="Top" Height="25" Width="50" Padding="0"/>
+        <Label Content="Offset" HorizontalAlignment="Left" Margin="277,101,0,0" VerticalAlignment="Top" Height="25" Width="50" Padding="0"/>
+        <Label Content="Print Height (Z)" HorizontalAlignment="Left" Margin="10,131,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Move Height (Z)" HorizontalAlignment="Left" Margin="10,161,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Print Speed (mm/s)" HorizontalAlignment="Left" Margin="10,191,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Move Speed (mm/s)" HorizontalAlignment="Left" Margin="10,221,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
+        <Label Content="Printer settings" HorizontalAlignment="Center" Height="45" Margin="0,10,0,0" VerticalAlignment="Top" Width="175" FontSize="24"/>
+        <Label Content="All sizes in mm" HorizontalAlignment="Center" Margin="0,40,0,0" VerticalAlignment="Top"/>
+
+    </Grid>
+</Window>

--- a/SVGtoGCODE/ConversionSettings.xaml
+++ b/SVGtoGCODE/ConversionSettings.xaml
@@ -25,6 +25,7 @@
         <Label Content="Move Speed (mm/s)" HorizontalAlignment="Left" Margin="10,221,0,0" VerticalAlignment="Top" Height="25" Width="150" Padding="0"/>
         <Label Content="Printer settings" HorizontalAlignment="Center" Height="45" Margin="0,10,0,0" VerticalAlignment="Top" Width="175" FontSize="24"/>
         <Label Content="All sizes in mm" HorizontalAlignment="Center" Margin="0,40,0,0" VerticalAlignment="Top"/>
+        <Button x:Name="ResetButton" Content="Reset all" HorizontalAlignment="Left" Margin="221,221,0,0" VerticalAlignment="Top" Width="51" Height="25" Click="ResetButton_Click"/>
 
     </Grid>
 </Window>

--- a/SVGtoGCODE/ConversionSettings.xaml.cs
+++ b/SVGtoGCODE/ConversionSettings.xaml.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Text.RegularExpressions;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace SVGtoGCODE
+{
+    /// <summary>
+    /// Interaction logic for ConversionSettings.xaml
+    /// </summary>
+    public partial class ConversionSettings : Window
+    {
+        public ConversionSettings()
+        {
+            InitializeComponent();
+        }
+        private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
+        {
+            Regex regex = new Regex("[^0-9]+");
+            e.Handled = regex.IsMatch(e.Text);
+        }
+
+        private void SettingBoxSizeX_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxSizeY_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxOffsetX_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxOffsetY_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxPrintHeight_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxMoveHeight_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxPrintSpeed_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+
+        private void SettingBoxMoveSpeed_TextChanged(object sender, TextChangedEventArgs e)
+        {
+
+        }
+    }
+}

--- a/SVGtoGCODE/ConversionSettings.xaml.cs
+++ b/SVGtoGCODE/ConversionSettings.xaml.cs
@@ -23,6 +23,11 @@ namespace SVGtoGCODE
         public ConversionSettings()
         {
             InitializeComponent();
+            RetrieveSettings();
+        }
+
+        private void RetrieveSettings()
+        {
             SettingBoxSizeX.Text = Properties.Settings.Default.SizeX.ToString();
             SettingBoxSizeY.Text = Properties.Settings.Default.SizeY.ToString();
             SettingBoxOffsetX.Text = Properties.Settings.Default.OffsetX.ToString();
@@ -32,50 +37,93 @@ namespace SVGtoGCODE
             SettingBoxPrintSpeed.Text = Properties.Settings.Default.PrintSpeed.ToString();
             SettingBoxMoveSpeed.Text = Properties.Settings.Default.MoveSpeed.ToString();
         }
+
+        private void DefaultSettings()
+        {
+            Properties.Settings.Default.SizeX = 148;
+            Properties.Settings.Default.SizeY = 105;
+            Properties.Settings.Default.OffsetX = -74;
+            Properties.Settings.Default.OffsetY = 70;
+            Properties.Settings.Default.PrintHeight = -50;
+            Properties.Settings.Default.MoveHeight = -30;
+            Properties.Settings.Default.PrintSpeed = 15;
+            Properties.Settings.Default.MoveSpeed = 50;
+            RetrieveSettings();
+        }
+
         private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
         {
-            Regex regex = new Regex("[^0-9]+");
+            Regex regex = new Regex("[^0-9-]+");
             e.Handled = regex.IsMatch(e.Text);
         }
 
         private void SettingBoxSizeX_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.SizeX = int.Parse(SettingBoxSizeX.Text);
+            if (SettingBoxSizeX.Text.Length > 0)
+            {
+                Properties.Settings.Default.SizeX = int.Parse(SettingBoxSizeX.Text);
+            }
         }
 
         private void SettingBoxSizeY_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.SizeY = int.Parse(SettingBoxSizeY.Text);
+            if (SettingBoxSizeY.Text.Length > 0)
+            {
+                Properties.Settings.Default.SizeY = int.Parse(SettingBoxSizeY.Text);
+            }
         }
 
         private void SettingBoxOffsetX_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.OffsetX = int.Parse(SettingBoxOffsetX.Text);
+            if (SettingBoxOffsetX.Text.Length > 0)
+            {
+                Properties.Settings.Default.OffsetX = int.Parse(SettingBoxOffsetX.Text);
+            }
         }
 
         private void SettingBoxOffsetY_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.OffsetY = int.Parse(SettingBoxOffsetY.Text);
+            if (SettingBoxOffsetY.Text.Length > 0)
+            {
+                Properties.Settings.Default.OffsetY = int.Parse(SettingBoxOffsetY.Text);
+            }
         }
 
         private void SettingBoxPrintHeight_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.PrintHeight = int.Parse(SettingBoxPrintHeight.Text);
+            if (SettingBoxPrintHeight.Text.Length > 0)
+            {
+                Properties.Settings.Default.PrintHeight = int.Parse(SettingBoxPrintHeight.Text);
+            }
         }
 
         private void SettingBoxMoveHeight_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.MoveHeight = int.Parse(SettingBoxMoveHeight.Text);
+            if (SettingBoxMoveHeight.Text.Length > 0)
+            {
+                Properties.Settings.Default.MoveHeight = int.Parse(SettingBoxMoveHeight.Text);
+            }
         }
 
         private void SettingBoxPrintSpeed_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.PrintSpeed = int.Parse(SettingBoxPrintSpeed.Text);
+            if (SettingBoxPrintSpeed.Text.Length > 0)
+            {
+                Properties.Settings.Default.PrintSpeed = int.Parse(SettingBoxPrintSpeed.Text);
+            }
         }
 
         private void SettingBoxMoveSpeed_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Properties.Settings.Default.MoveSpeed = int.Parse(SettingBoxMoveSpeed.Text);
+            if (SettingBoxMoveSpeed.Text.Length > 0)
+            {
+                Properties.Settings.Default.MoveSpeed = int.Parse(SettingBoxMoveSpeed.Text);
+            }
+        }
+
+        private void ResetButton_Click(object sender, RoutedEventArgs e)
+        {
+            DefaultSettings();
         }
     }
 }

--- a/SVGtoGCODE/ConversionSettings.xaml.cs
+++ b/SVGtoGCODE/ConversionSettings.xaml.cs
@@ -23,6 +23,14 @@ namespace SVGtoGCODE
         public ConversionSettings()
         {
             InitializeComponent();
+            SettingBoxSizeX.Text = Properties.Settings.Default.SizeX.ToString();
+            SettingBoxSizeY.Text = Properties.Settings.Default.SizeY.ToString();
+            SettingBoxOffsetX.Text = Properties.Settings.Default.OffsetX.ToString();
+            SettingBoxOffsetY.Text = Properties.Settings.Default.OffsetY.ToString();
+            SettingBoxPrintHeight.Text = Properties.Settings.Default.PrintHeight.ToString();
+            SettingBoxMoveHeight.Text = Properties.Settings.Default.MoveHeight.ToString();
+            SettingBoxPrintSpeed.Text = Properties.Settings.Default.PrintSpeed.ToString();
+            SettingBoxMoveSpeed.Text = Properties.Settings.Default.MoveSpeed.ToString();
         }
         private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
         {
@@ -32,42 +40,42 @@ namespace SVGtoGCODE
 
         private void SettingBoxSizeX_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.SizeX = int.Parse(SettingBoxSizeX.Text);
         }
 
         private void SettingBoxSizeY_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.SizeY = int.Parse(SettingBoxSizeY.Text);
         }
 
         private void SettingBoxOffsetX_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.OffsetX = int.Parse(SettingBoxOffsetX.Text);
         }
 
         private void SettingBoxOffsetY_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.OffsetY = int.Parse(SettingBoxOffsetY.Text);
         }
 
         private void SettingBoxPrintHeight_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.PrintHeight = int.Parse(SettingBoxPrintHeight.Text);
         }
 
         private void SettingBoxMoveHeight_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.MoveHeight = int.Parse(SettingBoxMoveHeight.Text);
         }
 
         private void SettingBoxPrintSpeed_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.PrintSpeed = int.Parse(SettingBoxPrintSpeed.Text);
         }
 
         private void SettingBoxMoveSpeed_TextChanged(object sender, TextChangedEventArgs e)
         {
-
+            Properties.Settings.Default.MoveSpeed = int.Parse(SettingBoxMoveSpeed.Text);
         }
     }
 }

--- a/SVGtoGCODE/FittedVector.cs
+++ b/SVGtoGCODE/FittedVector.cs
@@ -56,7 +56,8 @@ namespace SVGtoGCODE
             XmlNodeList elemList = vector.GetElementsByTagName("line");
             for (int i = 0; i < elemList.Count; i++)
             {
-                int x1 = int.Parse(elemList[i].Attributes["x1"].Value);
+                double x1ToParse = double.Parse(elemList[i].Attributes["x1"].Value);
+                int x1 = (int)Math.Round(x1ToParse, MidpointRounding.AwayFromZero);
                 if (!IsNegative(x1))
                 {
                     if (x1 > originalWidth)
@@ -74,7 +75,8 @@ namespace SVGtoGCODE
                     x1 = 0 + Properties.Settings.Default.OffsetX;
                 }
 
-                int y1 = int.Parse(elemList[i].Attributes["y1"].Value);
+                double y1ToParse = double.Parse(elemList[i].Attributes["y1"].Value);
+                int y1 = (int)Math.Round(y1ToParse, MidpointRounding.AwayFromZero);
                 if (!IsNegative(y1))
                 {
                     if (y1 > originalHeight)
@@ -102,7 +104,8 @@ namespace SVGtoGCODE
                 SendToGCode(x1, y1, Properties.Settings.Default.MoveHeight, MovementModes.Print);
                 SendToGCode(x1, y1, Properties.Settings.Default.PrintHeight, MovementModes.Print);
 
-                int x2 = int.Parse(elemList[i].Attributes["x2"].Value);
+                double x2ToParse = double.Parse(elemList[i].Attributes["x2"].Value);
+                int x2 = (int)Math.Round(x2ToParse, MidpointRounding.AwayFromZero);
                 if (!IsNegative(x2))
                 {
                     if (x2 > originalWidth)
@@ -120,7 +123,8 @@ namespace SVGtoGCODE
                     x2 = 0 + Properties.Settings.Default.OffsetX;
                 }
 
-                int y2 = int.Parse(elemList[i].Attributes["y2"].Value);
+                double y2ToParse = double.Parse(elemList[i].Attributes["y2"].Value);
+                int y2 = (int)Math.Round(y2ToParse, MidpointRounding.AwayFromZero);
                 if (!IsNegative(y2))
                 {
                     if (y2 > originalHeight)

--- a/SVGtoGCODE/FittedVector.cs
+++ b/SVGtoGCODE/FittedVector.cs
@@ -11,9 +11,18 @@ namespace SVGtoGCODE
     // inherit from vector
     public class FittedVector : Vector
     {
+        private int originalHeight;
+        private int originalWidth;
+        private int fittedHeight;
+        private int fittedWidth;
+        private double scalingMultiplier;
+
         // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space
         public FittedVector(XmlDocument vector)
         {
+            Workspace workspace = new Workspace();
+            fittedHeight = workspace.sizeY();
+            fittedWidth = workspace.sizeX();
             GetDocumentSize(vector);
         }
 
@@ -21,12 +30,19 @@ namespace SVGtoGCODE
         {
             // This works!
             // https://stackoverflow.com/questions/933687/read-xml-attribute-using-xmldocument
+
+            // Reads <svg> tag from xml file, then saves the height and width attributes.
             XmlNodeList elemList = vector.GetElementsByTagName("svg");
             for (int i = 0; i < elemList.Count; i++)
             {
-                string attrVal = elemList[i].Attributes["height"].Value;
-                string height = attrVal;
+                originalHeight = int.Parse(elemList[i].Attributes["height"].Value);
+                originalWidth = int.Parse(elemList[i].Attributes["width"].Value);
             }
+
+            // Calculates scaling multiplier
+            scalingMultiplier = (double)fittedHeight / (double)originalHeight;
+            scalingMultiplier = Math.Floor(scalingMultiplier * 100d) / 100d;
+
         }
     }
 }

--- a/SVGtoGCODE/FittedVector.cs
+++ b/SVGtoGCODE/FittedVector.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Svg;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace SVGtoGCODE
 {
@@ -10,5 +12,21 @@ namespace SVGtoGCODE
     public class FittedVector : Vector
     {
         // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space
+        public FittedVector(XmlDocument vector)
+        {
+            GetDocumentSize(vector);
+        }
+
+        private void GetDocumentSize(XmlDocument vector)
+        {
+            // This works!
+            // https://stackoverflow.com/questions/933687/read-xml-attribute-using-xmldocument
+            XmlNodeList elemList = vector.GetElementsByTagName("svg");
+            for (int i = 0; i < elemList.Count; i++)
+            {
+                string attrVal = elemList[i].Attributes["height"].Value;
+                string height = attrVal;
+            }
+        }
     }
 }

--- a/SVGtoGCODE/FittedVector.cs
+++ b/SVGtoGCODE/FittedVector.cs
@@ -61,17 +61,17 @@ namespace SVGtoGCODE
                 {
                     if (x1 > originalWidth)
                     {
-                        x1 = (int)(originalWidth * scalingMultiplier);
+                        x1 = (int)(originalWidth * scalingMultiplier) + Properties.Settings.Default.OffsetX;
 
                     }
                     else
                     {
-                        x1 = (int)(x1 * scalingMultiplier);
+                        x1 = (int)(x1 * scalingMultiplier) + Properties.Settings.Default.OffsetX;
                     }
                 }
                 else
                 {
-                    x1 = 0;
+                    x1 = 0 + Properties.Settings.Default.OffsetX;
                 }
 
                 int y1 = int.Parse(elemList[i].Attributes["y1"].Value);
@@ -79,28 +79,27 @@ namespace SVGtoGCODE
                 {
                     if (y1 > originalHeight)
                     {
-                        y1 = (int)(originalHeight * scalingMultiplier);
+                        y1 = (int)(originalHeight * scalingMultiplier) + Properties.Settings.Default.OffsetY;
 
                     }
                     else
                     {
-                        y1 = (int)(y1 * scalingMultiplier);
+                        y1 = (int)(y1 * scalingMultiplier) + Properties.Settings.Default.OffsetY;
                     }
                 }
                 else
                 {
-                    y1 = 0;
+                    y1 = 0 + Properties.Settings.Default.OffsetY;
                 }
 
-                // debug only
-                //cords.Add("X" + x1.ToString() + " Y" + y1.ToString());
-
                 // Moves the print head to the right X/Y position while maintaining height and speed on the first run to prevent unwanted marks.
-                if(i == 0)
+                if (i == 0)
                 {
                     SendToGCode(x1, y1, Properties.Settings.Default.MoveHeight, MovementModes.Move);
                 }
 
+                // Moves printhead to start of line, then lowers to draw.
+                SendToGCode(x1, y1, Properties.Settings.Default.MoveHeight, MovementModes.Print);
                 SendToGCode(x1, y1, Properties.Settings.Default.PrintHeight, MovementModes.Print);
 
                 int x2 = int.Parse(elemList[i].Attributes["x2"].Value);
@@ -108,17 +107,17 @@ namespace SVGtoGCODE
                 {
                     if (x2 > originalWidth)
                     {
-                        x2 = (int)(originalWidth * scalingMultiplier);
+                        x2 = (int)(originalWidth * scalingMultiplier) + Properties.Settings.Default.OffsetX;
 
                     }
                     else
                     {
-                        x2 = (int)(x2 * scalingMultiplier);
+                        x2 = (int)(x2 * scalingMultiplier) + Properties.Settings.Default.OffsetX;
                     }
                 }
                 else
                 {
-                    x2 = 0;
+                    x2 = 0 + Properties.Settings.Default.OffsetX;
                 }
 
                 int y2 = int.Parse(elemList[i].Attributes["y2"].Value);
@@ -126,31 +125,30 @@ namespace SVGtoGCODE
                 {
                     if (y2 > originalHeight)
                     {
-                        y2 = (int)(originalHeight * scalingMultiplier);
+                        y2 = (int)(originalHeight * scalingMultiplier) + Properties.Settings.Default.OffsetY;
 
                     }
                     else
                     {
-                        y2 = (int)(y2 * scalingMultiplier);
+                        y2 = (int)(y2 * scalingMultiplier) + Properties.Settings.Default.OffsetY;
                     }
                 }
                 else
                 {
-                    y2 = 0;
+                    y2 = 0 + Properties.Settings.Default.OffsetY;
                 }
 
-                // debug only
-                //cords.Add("\nX" + x2.ToString() + " Y" + y2.ToString());
-
+                // Moves to second point of line, then lifts up printhead.
                 SendToGCode(x2, y2, Properties.Settings.Default.PrintHeight, MovementModes.Print);
+                SendToGCode(x2, y2, Properties.Settings.Default.MoveHeight, MovementModes.Print);
+
 
                 // Lifts the printhead straight up after completing the last command to prevent unwanted marks when returning to home position.
-                if (i == elemList.Count)
+                if (i == elemList.Count - 1)
                 {
                     SendToGCode(x2, y2, Properties.Settings.Default.MoveHeight, MovementModes.Move);
+                    gcode.SaveGCode();
                 }
-
-
             }
         }
 

--- a/SVGtoGCODE/FittedVector.cs
+++ b/SVGtoGCODE/FittedVector.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SVGtoGCODE
+{
+    // inherit from vector
+    public class FittedVector : Vector
+    {
+        // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space
+    }
+}

--- a/SVGtoGCODE/GCode.cs
+++ b/SVGtoGCODE/GCode.cs
@@ -8,7 +8,28 @@ namespace SVGtoGCODE
 {
     public class GCode
     {
+        List<string> GCodeCommands;
         // Is able to convert instance of FittedVector into GCode that complies with the restrictions given in instance of Workspace.
         // Should be able to generate, save, and export GCode.
+        public GCode()
+        {
+            GCodeCommands = new List<string>();
+        }
+
+        private void AddCommand(int x, int y, int z)
+        {
+            GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString());
+        }
+
+        private void AddCommand(int x, int y, int z, int f)
+        {
+            GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString() + " F" + f.ToString());
+        }
+
+        public void SaveGCode()
+        {
+            // Should write list of commands to txt file.
+            // https://stackoverflow.com/questions/15300572/saving-lists-to-txt-file
+        }
     }
 }

--- a/SVGtoGCODE/GCode.cs
+++ b/SVGtoGCODE/GCode.cs
@@ -21,7 +21,7 @@ namespace SVGtoGCODE
             GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString());
         }
 
-        private void AddCommand(int x, int y, int z, int f)
+        public void AddCommand(int x, int y, int z, int f)
         {
             GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString() + " F" + f.ToString());
         }

--- a/SVGtoGCODE/GCode.cs
+++ b/SVGtoGCODE/GCode.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SVGtoGCODE
+{
+    public class GCode
+    {
+        // Is able to convert instance of FittedVector into GCode that complies with the restrictions given in instance of Workspace.
+        // Should be able to generate, save, and export GCode.
+    }
+}

--- a/SVGtoGCODE/GCode.cs
+++ b/SVGtoGCODE/GCode.cs
@@ -16,7 +16,7 @@ namespace SVGtoGCODE
             GCodeCommands = new List<string>();
         }
 
-        private void AddCommand(int x, int y, int z)
+        public void AddCommand(int x, int y, int z)
         {
             GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString());
         }

--- a/SVGtoGCODE/GCode.cs
+++ b/SVGtoGCODE/GCode.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using SVGtoGCODE.Models;
 
 namespace SVGtoGCODE
 {
@@ -21,15 +23,31 @@ namespace SVGtoGCODE
             GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString());
         }
 
-        public void AddCommand(int x, int y, int z, int f)
+        public void AddCommand(int x, int y, int z, MovementModes movementMode)
         {
-            GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString() + " F" + f.ToString());
+            switch (movementMode)
+            {
+                case MovementModes.Print:
+                    GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString() + " F" + Properties.Settings.Default.PrintSpeed);
+                    break;
+                case MovementModes.Move:
+                    GCodeCommands.Add("G1" + " X" + x.ToString() + " Y" + y.ToString() + " Z" + z.ToString() + " F" + Properties.Settings.Default.MoveSpeed);
+                    break;
+                default:
+                    break;
+            }
         }
 
         public void SaveGCode()
         {
             // Should write list of commands to txt file.
             // https://stackoverflow.com/questions/15300572/saving-lists-to-txt-file
+            TextWriter writer = new StreamWriter("D:\\GCode\\save1.GCODE");
+
+            foreach (String s in GCodeCommands)
+                writer.WriteLine(s);
+
+            writer.Close();
         }
     }
 }

--- a/SVGtoGCODE/MainWindow.xaml
+++ b/SVGtoGCODE/MainWindow.xaml
@@ -21,6 +21,7 @@
                 <Image x:Name="PreviewImage" Stretch="Fill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </Border>
         </Viewbox>
+        <Button Content="⚙" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="20" Height="20" Click="OpenSettings"/>
 
 
     </Grid>

--- a/SVGtoGCODE/MainWindow.xaml
+++ b/SVGtoGCODE/MainWindow.xaml
@@ -14,7 +14,7 @@
         <Grid Height="80" Margin="72,0,73,10.5" VerticalAlignment="Bottom" HorizontalAlignment="Center" Width="200" Grid.Row="1">
             <TextBlock x:Name="TextBlockStatus" Margin="0,0,0,40" TextWrapping="Wrap" Text="Status" TextAlignment="Center" Grid.RowSpan="2" Height="55" Width="200" ScrollViewer.CanContentScroll="True" Padding="5" ScrollViewer.HorizontalScrollBarVisibility="Auto" ToolTip="{Binding Text, ElementName=TextBlockStatus}" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
             <Button x:Name="ButtonSelectFile" Content="Select file" Margin="12,0,0,3" Click="Button_Select_Click" VerticalAlignment="Bottom" Height="20" Width="75" HorizontalAlignment="Left" MinWidth="75" MinHeight="20"/>
-            <Button x:Name="ButtonConvert" Content="Convert" Margin="0,0,12,3" Height="20" VerticalAlignment="Bottom" Width="75" HorizontalAlignment="Right" MinWidth="75" MinHeight="20"/>
+            <Button x:Name="ButtonConvert" Content="Convert" Margin="0,0,12,3" Height="20" VerticalAlignment="Bottom" Width="75" HorizontalAlignment="Right" MinWidth="75" MinHeight="20" Click="ButtonConvert_Click"/>
         </Grid>
         <Viewbox Margin="10" MinWidth="200" MinHeight="283">
             <Border BorderBrush="Black" BorderThickness="1" MinWidth="200" MinHeight="283" Margin="5">

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -1,48 +1,30 @@
 ﻿using System;
-using System.Drawing;
 using System.IO;
-using System.Security;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Win32;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using System.Windows.Navigation;
-using Svg;
-using System.Xml;
-
-
-// Declare vector instance globally, then initialise later. Constructor should work then.
-
 
 namespace SVGtoGCODE
 {
     public partial class MainWindow : Window
     {
-        Vector vector = new Vector();
-
+        Vector vector;
         public MainWindow()
         {
             InitializeComponent();
-            TextBlockStatus.Text = "Please select your file...";
+            UpdateStatusText("Please select your file...");
         }
 
         // Handles the select button.
         private void Button_Select_Click(object sender, RoutedEventArgs e)
         {
+            SelectSVG();
+        }
+
+        private void SelectSVG()
+        {
             Stream checkStream;
 
             // Opens file selection dialog with the user's documents folder as default. File input is restricted to .svg files.
-
-            // MOVE TO SEPARATE METHOD!!!!! 
             OpenFileDialog openFileDialog = new OpenFileDialog()
             {
                 FileName = "artwork.svg",
@@ -59,21 +41,22 @@ namespace SVGtoGCODE
                 {
                     if ((checkStream = openFileDialog.OpenFile()) != null)
                     {
-                        vector.Setup(System.IO.Path.GetFullPath(openFileDialog.FileName));
-                        DisplayController("Selected file:\n" + vector.SelectedFileName());
-                        PreviewController();
+
+                        vector = new Vector(System.IO.Path.GetFullPath(openFileDialog.FileName));
+                        UpdateStatusText("Selected file:\n" + vector.SelectedFileName());
+                        UpdatePreview();
                     }
                 }
                 catch (Exception ex)
                 {
                     string error = "Error: Could not read file from disk. Info: " + ex.Message;
-                    DisplayController("ERROR", error);
+                    UpdateStatusText("ERROR", error);
                 }
             }
             else
             {
                 string error = "Unknown error occurred. Please try again later.";
-                DisplayController("ERROR", error);
+                UpdateStatusText("ERROR", error);
             }
         }
 
@@ -84,121 +67,20 @@ namespace SVGtoGCODE
         }
 
         // Handles the preview window. Gets the preview from the current vector object.
-        private void PreviewController()
+        private void UpdatePreview()
         {
             PreviewImage.Source = vector.SendPreview();
         }
 
         // Handles all text to be shown to the user. Takes optional type argument as well as the message to display.
-        private void DisplayController(string message)
+        private void UpdateStatusText(string message)
         {
             TextBlockStatus.Text = message;
         }
-        private void DisplayController(string type, string message)
+
+        private void UpdateStatusText(string type, string message)
         {
             TextBlockStatus.Text = type + "!\n" + message;
         }
     }
 }
-
-// Class for working with imported vector files
-public class Vector
-{
-    /* TO DO
-       - Check aspect ratio/rotation on import, pad if necessary.
-       - Extract & convert vector shapes to GCode
-    */
-
-    // Variables for internal storage of data within class
-    private string filePath;
-    private string fileName;
-    private string tempSVG;
-    private BitmapImage preview;
-    private List<string> coordinates = new List<string>();
-
-    // Constructor, empty because class is created on programme startup
-    public Vector() { }
-
-    // Passes the right parameters to class on image selection
-    public void Setup(string path)
-    {
-        filePath = path;
-        CopySVGToTempDir();
-        try
-        {
-            CreatePreview();
-        }
-        catch (Exception)
-        {
-            throw;
-        }
-    }
-
-    // Gets the name of selected file. Handy for displaying it to the user.
-    public string SelectedFileName()
-    {
-        fileName = System.IO.Path.GetFileName(filePath);
-        return fileName;
-    }
-
-    // Returns the generated preview of the selected vector file.
-    public BitmapImage SendPreview()
-    {
-        return preview;
-    }
-
-    // Converts the SVG into GCode
-    public void Convert()
-    {
-        // TO DO
-    }
-
-    // Creates .PNG preview based on the selected vector file. Renders the vector shapes, then draws them in the bitmap image.
-    private void CreatePreview()
-    {
-        var svg = SvgDocument.Open(tempSVG);
-        svg.ShapeRendering = SvgShapeRendering.Auto;
-        Bitmap previewImage = svg.Draw();
-        MemoryStream ms = new MemoryStream();
-        ((System.Drawing.Bitmap)previewImage).Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-        preview = new BitmapImage();
-        preview.BeginInit();
-        ms.Seek(0, SeekOrigin.Begin);
-        preview.StreamSource = ms;
-        preview.EndInit();
-    }
-
-    // Copies the selected vector file to temp directory to prevent possible damage to the original file during transformation.
-    private void CopySVGToTempDir()
-    {
-        tempSVG = System.IO.Path.GetTempFileName();
-        try
-        {
-            File.Copy(filePath, tempSVG, true);
-        }
-        catch (Exception)
-        {
-            // TO DO: Exception handling
-            throw;
-        }
-    }
-
-    public class Workspace
-    {
-        // Holds the information about the defined workspace, such as the height and width dimensions.
-    }
-
-
-    // inherit from vector
-    public class FittedVector
-    {
-        // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space
-    }
-
-    public class GCode
-    {
-        // Is able to convert instance of FittedVector into GCode that complies with the restrictions given in instance of Workspace.
-        // Should be able to generate, save, and export GCode.
-    }
-}
-

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -80,5 +80,11 @@ namespace SVGtoGCODE
         {
             TextBlockStatus.Text = type + "!\n" + message;
         }
+
+        private void OpenSettings(object sender, RoutedEventArgs e)
+        {
+            ConversionSettings settings = new ConversionSettings();
+            settings.Show();
+        }
     }
 }

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Microsoft.Win32;
 using System.Windows;
+using SVGtoGCODE.Models;
 
 namespace SVGtoGCODE
 {

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ using System.Windows.Navigation;
 using Svg;
 using System.Xml;
 
+
 namespace SVGtoGCODE
 {
     public partial class MainWindow : Window
@@ -70,6 +71,12 @@ namespace SVGtoGCODE
             }
         }
 
+        // Handles the convert button
+        private void ButtonConvert_Click(object sender, RoutedEventArgs e)
+        {
+            vector.Convert();
+        }
+
         // Handles the preview window. Gets the preview from the current vector object.
         private void PreviewController()
         {
@@ -91,19 +98,17 @@ namespace SVGtoGCODE
 // Class for working with imported vector files
 public class Vector
 {
-    // Should have:
-    // Check aspect ratio/rotation on import, pad if necessary.
-    // X Function to create temporary copy
-    // X Path to temporary copy of file
-    // X generate random file name + be able to have it be requested publicly
-    // X Name (+ generator?)
-
+    /* TO DO
+       - Check aspect ratio/rotation on import, pad if necessary.
+       - Extract & convert vector shapes to GCode
+    */
 
     // Variables for internal storage of data within class
     private string filePath;
     private string fileName;
     private string tempSVG;
     private BitmapImage preview;
+    private List<string> coordinates = new List<string>();
 
     // Constructor, empty because class is created on programme startup
     public Vector() { }
@@ -127,6 +132,12 @@ public class Vector
     public BitmapImage SendPreview()
     {
         return preview;
+    }
+
+    // Converts the SVG into GCode
+    public void Convert()
+    {
+        // TO DO
     }
 
     // Creates .PNG preview based on the selected vector file. Renders the vector shapes, then draws them in the bitmap image.

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -20,11 +20,15 @@ using Svg;
 using System.Xml;
 
 
+// Declare vector instance globally, then initialise later. Constructor should work then.
+
+
 namespace SVGtoGCODE
 {
     public partial class MainWindow : Window
     {
         Vector vector = new Vector();
+
         public MainWindow()
         {
             InitializeComponent();
@@ -37,6 +41,8 @@ namespace SVGtoGCODE
             Stream checkStream;
 
             // Opens file selection dialog with the user's documents folder as default. File input is restricted to .svg files.
+
+            // MOVE TO SEPARATE METHOD!!!!! 
             OpenFileDialog openFileDialog = new OpenFileDialog()
             {
                 FileName = "artwork.svg",
@@ -118,7 +124,14 @@ public class Vector
     {
         filePath = path;
         CopySVGToTempDir();
-        CreatePreview();
+        try
+        {
+            CreatePreview();
+        }
+        catch (Exception)
+        {
+            throw;
+        }
     }
 
     // Gets the name of selected file. Handy for displaying it to the user.
@@ -175,6 +188,8 @@ public class Vector
         // Holds the information about the defined workspace, such as the height and width dimensions.
     }
 
+
+    // inherit from vector
     public class FittedVector
     {
         // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -49,8 +49,7 @@ namespace SVGtoGCODE
                 }
                 catch (Exception ex)
                 {
-                    string error = "Error: Could not read file from disk. Info: " + ex.Message;
-                    SetStatusText("ERROR", error);
+                    SetStatusText("ERROR", $"Error: Could not read file from disk. Info: {ex.Message}");
                 }
             }
             else

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -54,8 +54,7 @@ namespace SVGtoGCODE
             }
             else
             {
-                string error = "Unknown error occurred. Please try again later.";
-                SetStatusText("ERROR", error);
+                SetStatusText("ERROR", "Unknown error occurred. Please try again later.");
             }
         }
 

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -11,7 +11,7 @@ namespace SVGtoGCODE
         public MainWindow()
         {
             InitializeComponent();
-            UpdateStatusText("Please select your file...");
+            SetStatusText("Please select your file...");
         }
 
         // Handles the select button.
@@ -43,20 +43,20 @@ namespace SVGtoGCODE
                     {
 
                         vector = new Vector(System.IO.Path.GetFullPath(openFileDialog.FileName));
-                        UpdateStatusText("Selected file:\n" + vector.SelectedFileName());
+                        SetStatusText("Selected file:\n" + vector.SelectedFileName());
                         UpdatePreview();
                     }
                 }
                 catch (Exception ex)
                 {
                     string error = "Error: Could not read file from disk. Info: " + ex.Message;
-                    UpdateStatusText("ERROR", error);
+                    SetStatusText("ERROR", error);
                 }
             }
             else
             {
                 string error = "Unknown error occurred. Please try again later.";
-                UpdateStatusText("ERROR", error);
+                SetStatusText("ERROR", error);
             }
         }
 
@@ -73,12 +73,12 @@ namespace SVGtoGCODE
         }
 
         // Handles all text to be shown to the user. Takes optional type argument as well as the message to display.
-        private void UpdateStatusText(string message)
+        private void SetStatusText(string message)
         {
             TextBlockStatus.Text = message;
         }
 
-        private void UpdateStatusText(string type, string message)
+        private void SetStatusText(string type, string message)
         {
             TextBlockStatus.Text = type + "!\n" + message;
         }

--- a/SVGtoGCODE/MainWindow.xaml.cs
+++ b/SVGtoGCODE/MainWindow.xaml.cs
@@ -169,5 +169,21 @@ public class Vector
             throw;
         }
     }
+
+    public class Workspace
+    {
+        // Holds the information about the defined workspace, such as the height and width dimensions.
+    }
+
+    public class FittedVector
+    {
+        // Should hold the info for the instance of Vector which has been fitted in a specific printing/work space
+    }
+
+    public class GCode
+    {
+        // Is able to convert instance of FittedVector into GCode that complies with the restrictions given in instance of Workspace.
+        // Should be able to generate, save, and export GCode.
+    }
 }
 

--- a/SVGtoGCODE/Models/MovementModes.cs
+++ b/SVGtoGCODE/Models/MovementModes.cs
@@ -1,0 +1,8 @@
+﻿namespace SVGtoGCODE.Models
+{
+    public enum MovementModes
+    {
+        Print,
+        Move
+    }
+}

--- a/SVGtoGCODE/Properties/Settings.Designer.cs
+++ b/SVGtoGCODE/Properties/Settings.Designer.cs
@@ -8,22 +8,114 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace SVGtoGCODE.Properties
-{
-
-
+namespace SVGtoGCODE.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("148")]
+        public int SizeX {
+            get {
+                return ((int)(this["SizeX"]));
+            }
+            set {
+                this["SizeX"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("105")]
+        public int SizeY {
+            get {
+                return ((int)(this["SizeY"]));
+            }
+            set {
+                this["SizeY"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-74")]
+        public int OffsetX {
+            get {
+                return ((int)(this["OffsetX"]));
+            }
+            set {
+                this["OffsetX"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("70")]
+        public int OffsetY {
+            get {
+                return ((int)(this["OffsetY"]));
+            }
+            set {
+                this["OffsetY"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-50")]
+        public int PrintHeight {
+            get {
+                return ((int)(this["PrintHeight"]));
+            }
+            set {
+                this["PrintHeight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-30")]
+        public int MoveHeight {
+            get {
+                return ((int)(this["MoveHeight"]));
+            }
+            set {
+                this["MoveHeight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("15")]
+        public int PrintSpeed {
+            get {
+                return ((int)(this["PrintSpeed"]));
+            }
+            set {
+                this["PrintSpeed"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public int MoveSpeed {
+            get {
+                return ((int)(this["MoveSpeed"]));
+            }
+            set {
+                this["MoveSpeed"] = value;
             }
         }
     }

--- a/SVGtoGCODE/Properties/Settings.settings
+++ b/SVGtoGCODE/Properties/Settings.settings
@@ -1,7 +1,30 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="SVGtoGCODE.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="SizeX" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">148</Value>
+    </Setting>
+    <Setting Name="SizeY" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">105</Value>
+    </Setting>
+    <Setting Name="OffsetX" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">-74</Value>
+    </Setting>
+    <Setting Name="OffsetY" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">70</Value>
+    </Setting>
+    <Setting Name="PrintHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">-50</Value>
+    </Setting>
+    <Setting Name="MoveHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">-30</Value>
+    </Setting>
+    <Setting Name="PrintSpeed" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">15</Value>
+    </Setting>
+    <Setting Name="MoveSpeed" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/SVGtoGCODE/SVGtoGCODE.csproj
+++ b/SVGtoGCODE/SVGtoGCODE.csproj
@@ -63,6 +63,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="FittedVector.cs" />
+    <Compile Include="GCode.cs" />
+    <Compile Include="Vector.cs" />
+    <Compile Include="Workspace.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/SVGtoGCODE/SVGtoGCODE.csproj
+++ b/SVGtoGCODE/SVGtoGCODE.csproj
@@ -63,10 +63,17 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="ConversionSettings.xaml.cs">
+      <DependentUpon>ConversionSettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="FittedVector.cs" />
     <Compile Include="GCode.cs" />
     <Compile Include="Vector.cs" />
     <Compile Include="Workspace.cs" />
+    <Page Include="ConversionSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/SVGtoGCODE/SVGtoGCODE.csproj
+++ b/SVGtoGCODE/SVGtoGCODE.csproj
@@ -68,6 +68,7 @@
     </Compile>
     <Compile Include="FittedVector.cs" />
     <Compile Include="GCode.cs" />
+    <Compile Include="Models\MovementModes.cs" />
     <Compile Include="Vector.cs" />
     <Compile Include="Workspace.cs" />
     <Page Include="ConversionSettings.xaml">

--- a/SVGtoGCODE/Vector.cs
+++ b/SVGtoGCODE/Vector.cs
@@ -22,25 +22,11 @@ namespace SVGtoGCODE
         private BitmapImage preview;
         private List<string> coordinates = new List<string>();
 
-        // Constructor, empty because class is created on programme startup
+        // Constructor
         public Vector() { }
 
+        // Constructor. Passes the right parameters to class on image selection/instance creation
         public Vector(string path)
-        {
-            filePath = path;
-            CopySVGToTempDir();
-            try
-            {
-                CreatePreview();
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-        }
-
-        // Passes the right parameters to class on image selection
-        public void Setup(string path)
         {
             filePath = path;
             CopySVGToTempDir();

--- a/SVGtoGCODE/Vector.cs
+++ b/SVGtoGCODE/Vector.cs
@@ -1,0 +1,106 @@
+﻿using Svg;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Media.Imaging;
+
+namespace SVGtoGCODE
+{
+    // Class for working with imported vector files
+    public class Vector
+    {
+        /* TO DO
+           - Check aspect ratio/rotation on import, pad if necessary.
+           - Extract & convert vector shapes to GCode
+        */
+
+        // Variables for internal storage of data within class
+        private string filePath;
+        private string fileName;
+        private string tempSVG;
+        private BitmapImage preview;
+        private List<string> coordinates = new List<string>();
+
+        // Constructor, empty because class is created on programme startup
+        public Vector() { }
+
+        public Vector(string path)
+        {
+            filePath = path;
+            CopySVGToTempDir();
+            try
+            {
+                CreatePreview();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+        // Passes the right parameters to class on image selection
+        public void Setup(string path)
+        {
+            filePath = path;
+            CopySVGToTempDir();
+            try
+            {
+                CreatePreview();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+        // Gets the name of selected file. Handy for displaying it to the user.
+        public string SelectedFileName()
+        {
+            fileName = System.IO.Path.GetFileName(filePath);
+            return fileName;
+        }
+
+        // Returns the generated preview of the selected vector file.
+        public BitmapImage SendPreview()
+        {
+            return preview;
+        }
+
+        // Converts the SVG into GCode
+        public void Convert()
+        {
+            // TO DO
+        }
+
+        // Creates .PNG preview based on the selected vector file. Renders the vector shapes, then draws them in the bitmap image.
+        private void CreatePreview()
+        {
+            var svg = SvgDocument.Open(tempSVG);
+            svg.ShapeRendering = SvgShapeRendering.Auto;
+            Bitmap previewImage = svg.Draw();
+            MemoryStream ms = new MemoryStream();
+            ((System.Drawing.Bitmap)previewImage).Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+            preview = new BitmapImage();
+            preview.BeginInit();
+            ms.Seek(0, SeekOrigin.Begin);
+            preview.StreamSource = ms;
+            preview.EndInit();
+        }
+
+        // Copies the selected vector file to temp directory to prevent possible damage to the original file during transformation.
+        private void CopySVGToTempDir()
+        {
+            tempSVG = System.IO.Path.GetTempFileName();
+            try
+            {
+                File.Copy(filePath, tempSVG, true);
+            }
+            catch (Exception)
+            {
+                // TO DO: Exception handling
+                throw;
+            }
+        }
+    }
+}

--- a/SVGtoGCODE/Vector.cs
+++ b/SVGtoGCODE/Vector.cs
@@ -64,6 +64,10 @@ namespace SVGtoGCODE
         {
             var svg = SvgDocument.Open(tempSVG);
             svg.ShapeRendering = SvgShapeRendering.Auto;
+
+            // try using this to fix stuff :)
+            //svg.Transforms.Add(new Svg.Transforms.SvgRotate(90.0f));
+
             Bitmap previewImage = svg.Draw();
             MemoryStream ms = new MemoryStream();
             ((System.Drawing.Bitmap)previewImage).Save(ms, System.Drawing.Imaging.ImageFormat.Png);

--- a/SVGtoGCODE/Vector.cs
+++ b/SVGtoGCODE/Vector.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Windows.Media.Imaging;
+using System.Xml;
 
 namespace SVGtoGCODE
 {
@@ -56,7 +57,9 @@ namespace SVGtoGCODE
         // Converts the SVG into GCode
         public void Convert()
         {
-            // TO DO
+            XmlDocument vector = new XmlDocument();
+            vector.Load(tempSVG);
+            FittedVector vectorFitted = new FittedVector(vector);
         }
 
         // Creates .PNG preview based on the selected vector file. Renders the vector shapes, then draws them in the bitmap image.

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -20,19 +20,19 @@ namespace SVGtoGCODE
         // Holds the information about the defined workspace, such as the height and width dimensions.
         public Workspace()
         {
-
+            UpdateParameters();
         }
 
-        public Workspace(int sizeX, int sizeY, int offsetX, int offsetY, int printHeight, int moveHeight, int printSpeed, int moveSpeed)
+        public void UpdateParameters()
         {
-            _sizeX = sizeX;
-            _sizeY = sizeY;
-            _offsetX = offsetX;
-            _offsetY = offsetY;
-            _printHeight = printHeight;
-            _moveHeight = moveHeight;
-            _printSpeed = printSpeed;
-            _moveSpeed = moveSpeed;
+            _sizeX = Properties.Settings.Default.SizeX;
+            _sizeY = Properties.Settings.Default.SizeY;
+            _offsetX = Properties.Settings.Default.OffsetX;
+            _offsetY = Properties.Settings.Default.OffsetY;
+            _printHeight = Properties.Settings.Default.PrintHeight;
+            _moveHeight = Properties.Settings.Default.MoveHeight;
+            _printSpeed = Properties.Settings.Default.PrintSpeed;
+            _moveSpeed = Properties.Settings.Default.MoveSpeed;
         }
     }
 }

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -8,10 +8,31 @@ namespace SVGtoGCODE
 {
     public class Workspace
     {
+        private int _sizeX;
+        private int _sizeY;
+        private int _offsetX;
+        private int _offsetY;
+        private int _printHeight;
+        private int _moveHeight;
+        private int _printSpeed;
+        private int _moveSpeed;
+
         // Holds the information about the defined workspace, such as the height and width dimensions.
         public Workspace()
         {
 
+        }
+
+        public Workspace(int sizeX, int sizeY, int offsetX, int offsetY, int printHeight, int moveHeight, int printSpeed, int moveSpeed)
+        {
+            _sizeX = sizeX;
+            _sizeY = sizeY;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+            _printHeight = printHeight;
+            _moveHeight = moveHeight;
+            _printSpeed = printSpeed;
+            _moveSpeed = moveSpeed;
         }
     }
 }

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SVGtoGCODE
+{
+    public class Workspace
+    {
+        // Holds the information about the defined workspace, such as the height and width dimensions.
+    }
+}

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -23,6 +23,7 @@ namespace SVGtoGCODE
             UpdateParameters();
         }
 
+        // Updates the parameters/values based on the user-specified settings from the Conversion Settings dialog.
         public void UpdateParameters()
         {
             _sizeX = Properties.Settings.Default.SizeX;
@@ -34,5 +35,16 @@ namespace SVGtoGCODE
             _printSpeed = Properties.Settings.Default.PrintSpeed;
             _moveSpeed = Properties.Settings.Default.MoveSpeed;
         }
+
+
+        // Functions to return parameters of workspace when requested.
+        public int sizeX() { return _sizeX; }
+        public int sizeY() { return _sizeY; }
+        public int offsetX() { return _offsetX; }
+        public int offsetY() { return _offsetY; }
+        public int printHeight() { return _printHeight; }
+        public int moveHeight() { return _moveHeight; }
+        public int printSpeed() { return _printSpeed; }
+        public int moveSpeed() { return _moveSpeed; }
     }
 }

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -9,7 +9,7 @@ namespace SVGtoGCODE
     public class Workspace
     {
         // Holds the information about the defined workspace, such as the height and width dimensions.
-        Public void Workspace()
+        public Workspace()
         {
 
         }

--- a/SVGtoGCODE/Workspace.cs
+++ b/SVGtoGCODE/Workspace.cs
@@ -9,5 +9,9 @@ namespace SVGtoGCODE
     public class Workspace
     {
         // Holds the information about the defined workspace, such as the height and width dimensions.
+        Public void Workspace()
+        {
+
+        }
     }
 }


### PR DESCRIPTION
Allows the conversion of .svg files to .gcode. Makes sure that the resolution of the input matches that of the printer, and if necessary, makes adjustments to the fit. For now, it only accepts <line>.